### PR TITLE
Replace mashtree by attotree

### DIFF
--- a/.test/config.yaml
+++ b/.test/config.yaml
@@ -58,11 +58,11 @@ xz_threads:           1
 xz_params:            "-9"
 
 
-# (3) Mashtree parameters; notes:
+# (3) Attotree parameters; notes:
 #     - sketch size should be at least 10k to achieve a sufficient resolution
-mashtree_threads:     8
-mashtree_kmer_length: 21
-mashtree_sketch_size: 10000
+attotree_threads:     8
+attotree_kmer_length: 21
+attotree_sketch_size: 10000
 
 # (4) Jellyfish parameters
 jellyfish_threads:    8

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ for instance, ProPhyle is not installed unless Protocol 3 is used.
 The specifications of individual environments
 can be found in [`workflow/envs/`](workflow/envs/),
 and they contain:
+[Attotree](https://github.com/karel-brinda/attotree),
 [ETE 3](http://etetoolkit.org/),
 [SeqTK](https://github.com/lh3/seqtk),
 [xopen](https://pypi.org/project/xopen/),
 [Pandas](https://pandas.pydata.org/),
 [Jellyfish 2](https://github.com/gmarcais/Jellyfish),
-[Mashtree](https://github.com/lskatz/mashtree),
 [ProphAsm](https://github.com/prophyle/prophasm),
 and [ProPhyle](https://prophyle.github.io).
 
@@ -137,7 +137,8 @@ curl -L https://github.com/karel-brinda/miniphy/tarball/main \
   The supported input file formats include FASTA and FASTQ (possibly compressed by GZip).
 
 * ***Step 2 (optional): Provide corresponding phylogenies.*** \
-  Instead of estimating phylogenies by MashTree,
+  Instead of estimating phylogenies by [Attotree](https://github.com/karel-brinda/attotree)
+  (similar functionality like [Mashtree](https://github.com/lskatz/mashtree)),
   it is possible to supply custom phylogenies in the Newick format.
   The tree files should be named `input/{batch_name}.nw`,
   and the leave names inside should correspond
@@ -164,7 +165,7 @@ all options are documented directly there. The configurable functionality includ
 * protocols to use (asm, dGSs, dBGs with propagation),
 * analyzes to include (sequence and *k*-mer statistics),
 * *k* for de Bruijn graph and *k*-mer counting,
-* Mashtree parameters (phylogeny estimation),
+* Attotree parameters (phylogeny estimation),
 * XZ parameters (low-level compression), or
 * JellyFish parameters (*k*-mer counting).
 

--- a/config.yaml
+++ b/config.yaml
@@ -58,11 +58,11 @@ xz_threads:           1
 xz_params:            "-9"
 
 
-# (3) Mashtree parameters; notes:
+# (3) Attotree parameters; notes:
 #     - sketch size should be at least 10k to achieve a sufficient resolution
-mashtree_threads:     8
-mashtree_kmer_length: 21
-mashtree_sketch_size: 10000
+attotree_threads:     8
+attotree_kmer_length: 21
+attotree_sketch_size: 10000
 
 # (4) Jellyfish parameters
 jellyfish_threads:    8

--- a/workflow/envs/basic_env.yaml
+++ b/workflow/envs/basic_env.yaml
@@ -8,3 +8,4 @@ dependencies:
   - xopen ==1.7.0
   - pandas ==2.1.1
   - make ==4.3
+  - attotree ==0.1.0

--- a/workflow/envs/mashtree.yaml
+++ b/workflow/envs/mashtree.yaml
@@ -1,6 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-  - defaults
-dependencies:
-  - mashtree ==1.4.6

--- a/workflow/rules/tree.smk
+++ b/workflow/rules/tree.smk
@@ -77,14 +77,13 @@ if not config["trees_required"]:
             s=config["mashtree_sketch_size"],
             t=min(int(config["mashtree_threads"]), workflow.cores),  # ensure that the number of cores for MashTree doesn't go too low
         conda:
-            "../envs/mashtree.yaml"
+            "../envs/basic_env.yaml"
         shell:
             """
-            mashtree \\
-                --numcpus {params.t} \\
-                --kmerlength {params.k} \\
-                --sketch-size {params.s} \\
-                --seed 42  \\
+            attotree \\
+                -t {params.t} \\
+                -k {params.k} \\
+                -s {params.s} \\
                 {input} \\
                 | tee {output.nw}
             """

--- a/workflow/rules/tree.smk
+++ b/workflow/rules/tree.smk
@@ -62,8 +62,8 @@ rule symlink_nw_tree:
         """
 
 if not config["trees_required"]:
-    ruleorder: symlink_nw_tree > tree_newick_mashtree
-    rule tree_newick_mashtree:
+    ruleorder: symlink_nw_tree > tree_newick_attotree
+    rule tree_newick_attotree:
         """
         Infer a phylogenetic tree from the assemblies belonging to a given batch
         """
@@ -71,11 +71,11 @@ if not config["trees_required"]:
             nw=fn_tree_dirty(_batch="{batch}"),
         input:
             w_batch_asms,
-        threads: config["mashtree_threads"]
+        threads: config["attotree_threads"]
         params:
-            k=config["mashtree_kmer_length"],
-            s=config["mashtree_sketch_size"],
-            t=min(int(config["mashtree_threads"]), workflow.cores),  # ensure that the number of cores for MashTree doesn't go too low
+            k=config["attotree_kmer_length"],
+            s=config["attotree_sketch_size"],
+            t=min(int(config["attotree_threads"]), workflow.cores),  # ensure that the number of cores for Attotree doesn't go too low
         conda:
             "../envs/basic_env.yaml"
         shell:


### PR DESCRIPTION
Replacing mashtree by attotree (https://github.com/karel-brinda/attotree). It gives identical outputs, but it's many times faster and has very little dependencies.